### PR TITLE
Fix PR creation error handling in execute workflow

### DIFF
--- a/.github/workflows/sync_docs_execute.yml
+++ b/.github/workflows/sync_docs_execute.yml
@@ -422,15 +422,22 @@ jobs:
           EOF
           
           # Create the translation PR
+          echo "Creating translation PR..."
+          set +e  # Don't exit on error so we can capture it
           TRANSLATION_PR_URL=$(gh pr create \
             --base main \
             --head "$SYNC_BRANCH" \
             --title "🌐 Auto-translations for PR #${PR_NUMBER}: ${ORIGINAL_PR_TITLE}" \
             --body-file /tmp/translation_pr_body.md \
-            --label "🌐 translation" \
-            --label "🤖 automated" 2>/dev/null || echo "")
+            --label "translation" \
+            --label "automated" 2>&1)
+          CREATE_EXIT_CODE=$?
+          set -e  # Re-enable exit on error
           
-          if [ -n "$TRANSLATION_PR_URL" ]; then
+          echo "PR creation command exit code: $CREATE_EXIT_CODE"
+          echo "PR creation output: $TRANSLATION_PR_URL"
+          
+          if [ $CREATE_EXIT_CODE -eq 0 ] && [[ "$TRANSLATION_PR_URL" == *"github.com"* ]]; then
             # Extract PR number from URL
             TRANSLATION_PR_NUMBER=$(echo "$TRANSLATION_PR_URL" | grep -o '[0-9]\+$')
             echo "translation_pr_number=$TRANSLATION_PR_NUMBER" >> $GITHUB_OUTPUT
@@ -441,6 +448,8 @@ jobs:
             echo "✅ Translation PR created successfully: #${TRANSLATION_PR_NUMBER}"
           else
             echo "❌ Failed to create translation PR"
+            echo "Exit code: $CREATE_EXIT_CODE"
+            echo "Output: $TRANSLATION_PR_URL"
             echo "creation_successful=false" >> $GITHUB_OUTPUT
           fi
 


### PR DESCRIPTION
## Fix PR Creation Error Handling

This PR fixes the error handling in the execute workflow where PR creation failures were being suppressed, making debugging impossible.

### Problem
The execute workflow was failing to create translation PRs but the error was being suppressed:
```bash
gh pr create ... 2>/dev/null || echo ""
```

This made it impossible to see why PR creation was failing.

### Solution
1. **Remove error suppression**: Replace `2>/dev/null` with `2>&1` to capture errors
2. **Add proper exit code checking**: Check `$?` instead of just URL presence
3. **Add debug logging**: Log exit code and actual error messages
4. **Remove emoji labels**: Replace `🌐 translation` and `🤖 automated` with plain labels
5. **Better error reporting**: Show actual error when PR creation fails

### Changes Made
- Remove `2>/dev/null || echo ""` pattern that suppresses errors
- Add `set +e` / `set -e` to capture exit codes properly
- Check both exit code and URL format for success detection
- Add detailed logging for debugging
- Use plain labels instead of emoji labels

### Expected Result
- Workflow will show actual error messages when PR creation fails
- Better debugging capability for future issues
- More reliable PR creation success detection

### Testing
This should help debug why PR creation failed in Test 1A workflow run.

🤖 Generated with Claude Code