### PR TITLE
Fix analyze workflow: remove docs.json from files_to_sync

### DIFF
--- a/.github/workflows/sync_docs_analyze.yml
+++ b/.github/workflows/sync_docs_analyze.yml
@@ -225,18 +225,9 @@ jobs:
                           "type": "mdx" if file_path.endswith(".mdx") else "md"
                       })
           
-          # Add docs.json if it changed
-          with open("/tmp/docs_json_changed.txt") as f:
-              docs_json_changed = f.read().strip() == "true"
-          
-          if docs_json_changed:
-              # Get docs.json size (from repo root)
-              docs_json_size = os.path.getsize("docs.json")
-              files_to_sync.append({
-                  "path": "docs.json",
-                  "size": docs_json_size,
-                  "type": "json"
-              })
+          # Note: docs.json is handled separately via structure_changes
+          # It should not be added to files_to_sync as it's not translated,
+          # only its structure is mirrored to other language sections
           
           # Load structure changes
           with open("/tmp/structure_changes.json") as f:


### PR DESCRIPTION
## Summary
- Remove docs.json from files_to_sync list in analyze workflow
- docs.json should not be translated, only its structure mirrored to other language sections
- This is handled separately via structure_changes mechanism

## Changes
- Modified sync_docs_analyze.yml lines 228-230 to remove docs.json from files_to_sync
- Added explanatory comment about docs.json handling

🤖 Generated with [Claude Code](https://claude.ai/code)