### PR TITLE
Fix missing GH_TOKEN in execute workflow

### DIFF
--- a/.github/workflows/sync_docs_execute.yml
+++ b/.github/workflows/sync_docs_execute.yml
@@ -369,6 +369,8 @@ jobs:
       - name: Commit and create translation PR
         if: steps.sync.outputs.has_changes == 'true'
         id: create-translation-pr
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           PR_NUMBER="${{ steps.extract-artifacts.outputs.pr_number }}"
           SYNC_BRANCH="docs-sync-pr-${PR_NUMBER}"


### PR DESCRIPTION
## Summary
- Add missing `GH_TOKEN` environment variable to PR creation step in execute workflow
- This was causing translation PR creation to fail with error: "set the GH_TOKEN environment variable"

## Problem
The execute workflow was failing to create translation PRs because the GitHub CLI didn't have access to the authentication token.

## Solution
Added `env: GH_TOKEN: ${{ github.token }}` to the "Commit and create translation PR" step.

🤖 Generated with [Claude Code](https://claude.ai/code)