### PR TITLE
Fix Python import path for temporary sync script

### DIFF
--- a/.github/workflows/sync_docs_execute.yml
+++ b/.github/workflows/sync_docs_execute.yml
@@ -267,8 +267,8 @@ jobs:
           import asyncio
           from pathlib import Path
           
-          # Add parent directory to path
-          sys.path.append(os.path.dirname(__file__))
+          # Add tools/translate directory to path (script runs from repo root)
+          sys.path.append('tools/translate')
           from sync_and_translate import DocsSynchronizer
           
           async def secure_sync():


### PR DESCRIPTION
## 🔧 Fix Critical Import Path Issue

Fixes the `ModuleNotFoundError: No module named 'sync_and_translate'` that was causing the execute workflow to fail.

### Problem:
- Script created in `/tmp/secure_sync.py` (outside repo)
- Used `sys.path.append(os.path.dirname(__file__))` which pointed to `/tmp/`
- Could not find `sync_and_translate` module in `tools/translate/`

### Solution:
- Change to `sys.path.append('tools/translate')`
- Script runs from repo root, so relative path works correctly
- Keeps script truly temporary (in `/tmp/`) while fixing imports

### Impact:
- ✅ Script stays in `/tmp/` (not committed to git)
- ✅ Can import translation modules properly  
- ✅ Should resolve the workflow failure

Ready to test! 🚀

🤖 Generated with [Claude Code](https://claude.ai/code)