### PR TITLE
Test 1C: Remove deprecated guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -30,7 +30,8 @@
                                         "pages": [
                                             "en/documentation/pages/getting-started/introduction",
                                             "en/documentation/pages/getting-started/quick-start",
-                                            "en/documentation/pages/getting-started/key-concepts"
+                                            "en/documentation/pages/getting-started/key-concepts",
+                                            "en/documentation/pages/getting-started/deprecated-guide"
                                         ]
                                     },
                                     {

--- a/docs.json
+++ b/docs.json
@@ -30,8 +30,7 @@
                                         "pages": [
                                             "en/documentation/pages/getting-started/introduction",
                                             "en/documentation/pages/getting-started/quick-start",
-                                            "en/documentation/pages/getting-started/key-concepts",
-                                            "en/documentation/pages/getting-started/deprecated-guide"
+                                            "en/documentation/pages/getting-started/key-concepts"
                                         ]
                                     },
                                     {

--- a/en/documentation/pages/getting-started/deprecated-guide.mdx
+++ b/en/documentation/pages/getting-started/deprecated-guide.mdx
@@ -1,0 +1,9 @@
+---
+title: "Deprecated Guide"
+description: "This guide is deprecated and will be removed"
+icon: "warning"
+---
+
+# Deprecated Guide
+
+This guide is deprecated and scheduled for removal.


### PR DESCRIPTION
Test case for removing English documentation with navigation updates

This PR removes:
- English file: en/documentation/pages/getting-started/deprecated-guide.mdx  
- Corresponding navigation entry from docs.json

Expected auto-translation behavior:
- Should remove zh-hans and ja-jp translations of deprecated-guide.mdx
- Should remove navigation entries from translated sections in docs.json